### PR TITLE
Add [MetaProvides::Package] to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -43,6 +43,7 @@ JSON::MaybeXS = 0
 [ReadmeAnyFromPod / MarkdownInRoot]
 filename = README.md
 
+[MetaProvides::Package]
 [MetaJSON]
 [MetaTests]
 [Test::Compile]


### PR DESCRIPTION
Hi! Thanks for maintaining WebService-Client. We worked on it as part of our CPAN Pull Request Challenge assignment. Here's my commit message:

Without it, META.yml file is missing {provides},
which was reported as an "experimental issue" at
https://cpants.cpanauthors.org/dist/WebService-Client