### PR TITLE
Add [MinimumPerl] to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ version = 0.0601
 -remove = GatherDir
 
 [AutoPrereqs]
+[MinimumPerl]
 
 [ChangelogFromGit]
 max_age = 3650


### PR DESCRIPTION
Without it, META.yml file is missing {requires}{perl},
which was reported as an "extra issue" at
https://cpants.cpanauthors.org/dist/WebService-Client