### PR TITLE
Avoid cruft files in release

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,7 +20,7 @@ max_age = 3650
 [CopyFilesFromBuild]
 copy = Makefile.PL
 
-[GatherDir]
+[Git::GatherDir]
 exclude_filename = Makefile.PL
 
 [MetaResources]


### PR DESCRIPTION
Note that the last release 1.0001 includes
files like foo.pl and stocks.pl. These files
should not have been part of the tarball as
they are not versionned in git.

Switch to Git::GatherDir to avoid such mistakes
in the future.