### PR TITLE
Fix each() iterator corruption in _php_params

### DIFF
--- a/lib/WebService/Client.pm
+++ b/lib/WebService/Client.pm
@@ -254,7 +254,8 @@ sub _content {
 sub _php_params {
     my ($self, $params) = @_;
     my %php;
-    while (my ($key, $value) = each %$params) {
+    for my $key (keys %$params) {
+        my $value = $params->{$key};
         if (is_plain_arrayref($value)) {
             $php{"$key\[]"} = $value;
         }


### PR DESCRIPTION
Replace each() with keys() + index to avoid corrupting the hash's internal iterator. When _php_params was called on a hashref that was also being externally iterated with each(), the two iterators would interfere, causing skipped keys and wrong query strings.

My bad from previous commit.