### PR TITLE
Use decoded_content instead of content in default deserializer

### DIFF
--- a/lib/WebService/Client.pm
+++ b/lib/WebService/Client.pm
@@ -58,7 +58,7 @@ has deserializer => (
         my $json = $self->json;
         sub {
             my ($res, %args) = @_;
-            return $json->decode($res->content);
+            return $json->decode($res->decoded_content);
         }
     },
 );

--- a/t/00-test-get.t
+++ b/t/00-test-get.t
@@ -115,4 +115,27 @@ subtest 'GET without params' => sub {
   is scalar @$widgets, 1, 'correct amount of values in returned list';
 };
 
+subtest 'GET with gzipped response' => sub {
+  use Compress::Zlib qw(memGzip);
+
+  my $json_data = '{"name":"José"}';
+  my $gzipped = memGzip($json_data);
+
+  my $useragent = Test::LWP::UserAgent->new;
+  $useragent->map_response(
+    qr{example.com/gzip},
+    HTTP::Response->new(
+      '200', 'OK',
+      ['Content-Type' => 'application/json', 'Content-Encoding' => 'gzip'],
+      $gzipped,
+    ),
+  );
+
+  my $webservice = WebService::Foo->new(ua => $useragent);
+
+  my $result = $webservice->get('/gzip');
+  ok $result, 'deserialized gzipped response';
+  is $result->{name}, 'José', 'correct value from gzipped response';
+};
+
 done_testing();


### PR DESCRIPTION
Switch from ->content to ->decoded_content so that Content-Encoding (e.g. gzip) is properly handled before JSON deserialization. Without this, gzipped response bodies would be passed as raw compressed bytes to the JSON decoder, causing a parse failure.

Also adds a test with a gzipped response to cover this path.

Consistent with WebService::Client::Response::data() which already uses decoded_content (commit d133246).