### PR TITLE
Fix loose _url regex allowing http-prefixed paths to bypass base_url

### DIFF
--- a/lib/WebService/Client.pm
+++ b/lib/WebService/Client.pm
@@ -206,7 +206,7 @@ sub prepare_response {
 sub _url {
     my ($self, $path) = @_;
     croak 'The path is missing' unless defined $path;
-    return $path =~ /^http/ ? $path : $self->base_url . $path;
+    return $path =~ m{^https?://} ? $path : $self->base_url . $path;
 }
 
 sub _headers {

--- a/t/00-test-get.t
+++ b/t/00-test-get.t
@@ -138,4 +138,24 @@ subtest 'GET with gzipped response' => sub {
   is $result->{name}, 'José', 'correct value from gzipped response';
 };
 
+subtest 'GET with url-like paths' => sub {
+  my $useragent = Test::LWP::UserAgent->new;
+  $useragent->map_response(
+    qr{.*},
+    HTTP::Response->new('200', 'OK', ['Content-Type' => 'application/json'], '{}'),
+  );
+
+  my $webservice = WebService::Foo->new(ua => $useragent);
+
+  $webservice->get('http:/evil.com/api');
+  my $url = $useragent->last_http_request_sent->uri;
+  is "$url", 'https://example.comhttp:/evil.com/api',
+    'http:/... treated as relative path, appended to base_url';
+
+  $webservice->get('https://valid.com/api');
+  $url = $useragent->last_http_request_sent->uri;
+  is "$url", 'https://valid.com/api',
+    'https://... treated as absolute URL, base_url bypassed';
+};
+
 done_testing();


### PR DESCRIPTION
The regex /^http/ matched any path starting with 'http' (e.g. 'http:/evil.com/api'), treating it as an absolute URL and bypassing base_url. Tightened to m{^https?://} so only valid scheme-prefixed URLs are treated as absolute.