### PR TITLE
Use defined-or instead of logical-or for default headers

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use 5.006;
+use 5.010;
 
 use ExtUtils::MakeMaker;
 
@@ -14,7 +14,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "WebService-Client",
   "LICENSE" => "perl",
-  "MIN_PERL_VERSION" => "5.006",
+  "MIN_PERL_VERSION" => "5.010",
   "NAME" => "WebService::Client",
   "PREREQ_PM" => {
     "Carp" => 0,

--- a/lib/WebService/Client.pm
+++ b/lib/WebService/Client.pm
@@ -208,7 +208,7 @@ sub _url {
 
 sub _headers {
     my ($self, $args) = @_;
-    my $headers = $args->{headers} ||= {};
+    my $headers = $args->{headers} // {};
     croak 'The headers param must be a hashref' unless is_plain_hashref($headers);
     $headers->{content_type} = $self->content_type
         unless _content_type($headers);

--- a/t/00-test-get.t
+++ b/t/00-test-get.t
@@ -175,4 +175,22 @@ subtest 'GET with url-like paths' => sub {
     'https://... treated as absolute URL, base_url bypassed';
 };
 
+subtest 'invalid headers are rejected' => sub {
+  my $useragent = Test::LWP::UserAgent->new;
+  $useragent->map_response(
+    qr{.*},
+    HTTP::Response->new('200', 'OK', ['Content-Type' => 'application/json'], '{}'),
+  );
+
+  my $webservice = WebService::Foo->new(ua => $useragent);
+
+  eval { $webservice->get('/foo', {}, headers => 0) };
+  ok $@, 'headers => 0 croaks';
+  like $@, qr/headers param must be a hashref/, 'correct error message';
+
+  eval { $webservice->get('/foo', {}, headers => '') };
+  ok $@, 'headers => "" croaks';
+  like $@, qr/headers param must be a hashref/, 'correct error message for empty string';
+};
+
 done_testing();


### PR DESCRIPTION
||= replaced undef, 0, and '' with {} silently, hiding invalid non-hashref values from the is_plain_hashref validation croak. Changed to // which only replaces undef, allowing invalid values like 0 and '' to properly produce an error.