### PR TITLE
fix: guard Response type-check against non-object values

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,7 @@ HTTP::Response::Stringable = 0.0002
 Moo = 1.005000
 JSON::MaybeXS = 0
 Ref::Util = 0
+Scalar::Util = 0
 URI = 0
 
 [Prereqs / TestRequires]

--- a/lib/WebService/Client/Response.pm
+++ b/lib/WebService/Client/Response.pm
@@ -4,12 +4,13 @@ use Moo;
 # VERSION
 
 use JSON::MaybeXS ();
+use Scalar::Util qw(blessed);
 
 has res => (
     is => 'ro',
     isa => sub {
         die 'res must be a HTTP::Response object'
-            unless shift->isa('HTTP::Response');
+            unless blessed($_[0]) && $_[0]->isa('HTTP::Response');
     },
     required => 1,
     handles => [qw(


### PR DESCRIPTION
This is fairly trivial defensive behavior if a non-object is passed in by mistake.