### PR TITLE
fix: stop sending Content-Type header on DELETE requests

### DIFF
--- a/lib/WebService/Client.pm
+++ b/lib/WebService/Client.pm
@@ -4,7 +4,7 @@ use Moo::Role;
 # VERSION
 
 use Carp qw(croak);
-use Ref::Util qw(is_plain_arrayref is_plain_coderef is_plain_hashref);
+use Ref::Util qw(is_hashref is_plain_arrayref is_plain_coderef);
 use URI ();
 use HTTP::Request ();
 use HTTP::Request::Common qw(DELETE GET PATCH POST PUT);
@@ -144,7 +144,9 @@ sub patch {
 
 sub delete {
     my ($self, $path, %args) = @_;
-    my $headers = $self->_headers(\%args);
+    my $headers = $args{headers} || {};
+    croak 'The headers param must be a hashref'
+        unless is_hashref($headers);
     my $url = $self->_url($path);
     my $req = DELETE $url, %$headers;
     return $self->req($req, %args);
@@ -210,7 +212,8 @@ sub _headers {
     my ($self, $args) = @_;
     my $headers = $args->{headers} // {};
     $args->{headers} = $headers;
-    croak 'The headers param must be a hashref' unless is_plain_hashref($headers);
+    croak 'The headers param must be a hashref'
+        unless is_hashref($headers);
     $headers->{content_type} = $self->content_type
         unless _content_type($headers);
     return $headers;

--- a/t/00-test-verbs.t
+++ b/t/00-test-verbs.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Test::LWP::UserAgent;
-use Test::More;
+use Test::More import => [qw( done_testing is like ok subtest )];
 
 {
   package WebService::Foo;
@@ -130,6 +130,22 @@ subtest 'PATCH' => sub {
   is $req->uri->as_string, 'https://example.com/widgets/1', 'correct URL';
   like $req->header('Content-Type'), qr{application/json}, 'Content-Type is set';
   is $req->content, '{"color":"blue"}', 'body is JSON-encoded';
+};
+
+subtest 'DELETE' => sub {
+  my $useragent = Test::LWP::UserAgent->new;
+  $useragent->map_response(
+    qr{example.com/widgets/1},
+    HTTP::Response->new('200', 'OK', ['Content-Type' => 'application/json'], '{}'),
+  );
+
+  my $webservice = WebService::Foo->new(ua => $useragent);
+
+  $webservice->delete('/widgets/1');
+  my $req = $useragent->last_http_request_sent;
+  is $req->method, 'DELETE', 'method is DELETE';
+  is $req->uri->as_string, 'https://example.com/widgets/1', 'correct URL';
+  ok !$req->header('Content-Type'), 'no Content-Type header on DELETE';
 };
 
 subtest 'GET with gzipped response' => sub {


### PR DESCRIPTION
DELETE requests have no body, so sending Content-Type is incorrect and rejected by some APIs. This is a breaking change -- callers that relied on the old behavior must set Content-Type explicitly via the headers argument.